### PR TITLE
Create Windows Registry Items on Install

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -287,12 +287,12 @@ impl AppConfiguration {
         Ok(())
     }
 
-    fn create_configuration_storage_if_not_exists() -> Result<(), ConfigurationError> {
+    pub fn create_configuration_storage_if_not_exists() -> Result<(), ConfigurationError> {
         Registry::with_default_root_key()?;
         Ok(())
     }
 
-    fn create_configuration_if_not_exists() -> Result<(), ConfigurationError> {
+    pub fn create_configuration_if_not_exists() -> Result<(), ConfigurationError> {
         log::debug!("Checking whether configuration needs to be created");
 
         if let existing_configuration = Self::fetch() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,8 @@ fn init_logging() {
 
 #[cfg(windows)]
 fn install() -> Result<()> {
+    AppConfiguration::create_configuration_storage_if_not_exists()?;
+    AppConfiguration::create_configuration_if_not_exists()?;
     crate::windows_listener_service::shutdown_on_lan_service::install()
 }
 


### PR DESCRIPTION
Ensures registry items exist prior to starting the Windows Service.