### PR TITLE
Use global interface binding

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -326,13 +326,11 @@ impl ToSocketAddrs for AppConfiguration {
     fn to_socket_addrs(&self) -> std::io::Result<vec::IntoIter<SocketAddr>> {
         let mut addresses: Vec<SocketAddr> = Vec::new();
 
-        log::info!("Read configuration with addresses: {:?}", self.addresses);
+        log::info!("Read configuration with port number: {:?}", self.port_number);
 
-        for ip in self.addresses.clone() {
-            addresses.push(SocketAddr::from((ip, self.port_number)));
-        }
+        let address = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
 
-        log::info!("Translated configuration into: {:?}", addresses);
+        addresses.push(SocketAddr::from((address, self.port_number)));
 
         let ret = addresses.into_iter();
         Ok(ret)

--- a/src/listener_service.rs
+++ b/src/listener_service.rs
@@ -12,6 +12,13 @@ pub fn run(configuration: &AppConfiguration) {
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
+                let interface_ip = stream.local_addr().unwrap().ip();
+                log::debug!("IP: {:?}", interface_ip);
+
+                if !configuration.addresses.contains(&interface_ip) {
+                    log::debug!("Received a shutdown signal on {:?}, but the configuration only allows them from {:?} – ignoring", interface_ip, configuration.addresses);
+                }
+
                 let secret = configuration.secret.clone();
 
                 thread::spawn(move || {


### PR DESCRIPTION
Instead of binding to a specific IP address, bind to the port globally across all interfaces. Then when a request comes in, check whether it should be allowed based on the configuration.

This should resolve issues with Windows Services not working correctly